### PR TITLE
Windows fixes

### DIFF
--- a/gst/gst-gtuber/gstgtubersrc.c
+++ b/gst/gst-gtuber/gstgtubersrc.c
@@ -463,9 +463,10 @@ insert_chapter_cb (guint64 time, const gchar *name, GstTocEntry *entry)
   gchar *id;
 
   clock_time = time * GST_MSECOND;
-  GST_DEBUG ("Inserting TOC chapter, time: %lu, name: %s", clock_time, name);
+  GST_DEBUG ("Inserting TOC chapter, time: %" G_GUINT64_FORMAT ", name: %s",
+      clock_time, name);
 
-  id = g_strdup_printf ("chap.%lu", time);
+  id = g_strdup_printf ("chap.%" G_GUINT64_FORMAT, time);
   subentry = gst_toc_entry_new (GST_TOC_ENTRY_TYPE_CHAPTER, id);
   g_free (id);
 

--- a/gtuber/gtuber-cache.c
+++ b/gtuber/gtuber-cache.c
@@ -444,8 +444,8 @@ gtuber_cache_read_config (FILE *file, GCancellable *cancellable,
     return FALSE;
   }
 
-  g_debug ("Config compared, mod_time: %li %s %li, "
-      "n_files: %u %s %u",
+  g_debug ("Config compared, mod_time: %"
+      G_GINT64_FORMAT " %s %" G_GINT64_FORMAT ", n_files: %u %s %u",
       config_mod_time, (config_mod_time != latest_time) ? "!=" : "==", latest_time,
       config_n_files, (config_n_files != n_files) ? "!=" : "==", n_files);
 
@@ -480,7 +480,8 @@ gtuber_cache_write_config (FILE *file, GCancellable *cancellable,
     return FALSE;
   }
 
-  g_debug ("Writing config dir data, config_mod_time: %li, config_n_files: %u",
+  g_debug ("Writing config dir data, config_mod_time: %"
+      G_GINT64_FORMAT ", config_n_files: %u",
       config_mod_time, config_n_files);
 
   write_ptr_to_file (file, &config_mod_time, sizeof (gint64));
@@ -568,8 +569,8 @@ gtuber_cache_read_plugins_compat (FILE *file,
   changed = (cache_mod_time != latest_time
       || cache_n_plugins != n_plugins);
 
-  g_debug ("Cache compared, mod_time: %li %s %li, "
-      "n_plugins: %u %s %u",
+  g_debug ("Cache compared, mod_time: %"
+      G_GINT64_FORMAT " %s %" G_GINT64_FORMAT ", n_plugins: %u %s %u",
       cache_mod_time, (cache_mod_time != latest_time) ? "!=" : "==", latest_time,
       cache_n_plugins, (cache_n_plugins != n_plugins) ? "!=" : "==", n_plugins);
 
@@ -642,8 +643,8 @@ gtuber_cache_write_plugins_compat (FILE *file,
   gtuber_cache_enumerate_plugins (dir, module_names, &mod_time, &n_plugins,
       cancellable, error);
 
-  g_debug ("Writing plugin dir data, mod_time: %li, n_plugins: %u",
-      mod_time, n_plugins);
+  g_debug ("Writing plugin dir data, mod_time: %"
+      G_GINT64_FORMAT ", n_plugins: %u", mod_time, n_plugins);
 
   write_ptr_to_file (file, &mod_time, sizeof (gint64));
   write_ptr_to_file (file, &n_plugins, sizeof (guint));
@@ -1072,7 +1073,7 @@ gtuber_cache_plugin_write_epoch (const gchar *plugin_name,
   if (file) {
     write_ptr_to_file (file, &epoch, sizeof (gint64));
     write_string (file, val);
-    g_debug ("Written cache value: %s, expires: %li",
+    g_debug ("Written cache value: %s, expires: %" G_GINT64_FORMAT,
         val, epoch);
 
     fclose (file);

--- a/gtuber/gtuber-manifest-generator.c
+++ b/gtuber/gtuber-manifest-generator.c
@@ -369,13 +369,14 @@ add_option_string (GString *string, const gchar *key, const gchar *value)
 static void
 add_option_int (GString *string, const gchar *key, guint64 value)
 {
-  g_string_append_printf (string, " %s=\"%lu\"", key, value);
+  g_string_append_printf (string, " %s=\"%" G_GUINT64_FORMAT "\"", key, value);
 }
 
 static void
 add_option_range (GString *string, const gchar *key, guint64 start, guint64 end)
 {
-  g_string_append_printf (string, " %s=\"%lu-%lu\"", key, start, end);
+  g_string_append_printf (string, " %s=\"%" G_GUINT64_FORMAT "-%" G_GUINT64_FORMAT "\"",
+      key, start, end);
 }
 
 static void

--- a/gtuber/meson.build
+++ b/gtuber/meson.build
@@ -213,5 +213,5 @@ gtuber_dep = declare_dependency(
   link_with: gtuber_lib,
   include_directories: conf_inc,
   dependencies: gtuber_deps,
-  sources: gtuber_enums,
+  sources: [gtuber_version_header, gtuber_enums[1]],
 )

--- a/plugins/peertube/gtuber-peertube.c
+++ b/plugins/peertube/gtuber-peertube.c
@@ -132,7 +132,7 @@ parse_response_data (GtuberPeertube *self, JsonParser *parser,
   JsonReader *reader = json_reader_new (json_parser_get_root (parser));
   gchar *id;
 
-  id = g_strdup_printf ("%li", gtuber_utils_json_get_int (reader, "id", NULL));
+  id = g_strdup_printf ("%" G_GINT64_FORMAT, gtuber_utils_json_get_int (reader, "id", NULL));
   gtuber_media_info_set_id (info, id);
   g_free (id);
 

--- a/plugins/twitch/gtuber-twitch.c
+++ b/plugins/twitch/gtuber-twitch.c
@@ -478,8 +478,12 @@ fail:
 static GtuberFlow
 create_hls_msg (GtuberTwitch *self, SoupMessage **msg, GError **error)
 {
-  gchar *p_id = g_strdup_printf ("%i", (rand () % 9000000) + 1000000);
-  gchar *path, *query, *uri_str;
+  GRand *rand;
+  gchar *p_id, *path, *query, *uri_str;
+
+  rand = g_rand_new ();
+  p_id = g_strdup_printf ("%" G_GINT32_FORMAT, g_rand_int_range (rand, 1000000, 10000000));
+  g_rand_free (rand);
 
   path = (self->media_type == TWITCH_MEDIA_CHANNEL)
     ? g_strdup_printf ("/api/channel/hls/%s.m3u8", self->video_id)

--- a/utils/common/gtuber-utils-common.c
+++ b/utils/common/gtuber-utils-common.c
@@ -470,7 +470,7 @@ gtuber_utils_common_parse_hls_input_stream_with_base_uri (GInputStream *stream,
             guint old_bitrate, bitrate;
 
             old_bitrate = gtuber_stream_get_bitrate (bstream);
-            bitrate = atoi (str);
+            bitrate = g_ascii_strtoull (str, NULL, 10);
 
             /* Use average bitrate if available */
             if (old_bitrate == 0 || old_bitrate > bitrate) {
@@ -483,8 +483,8 @@ gtuber_utils_common_parse_hls_input_stream_with_base_uri (GInputStream *stream,
             gchar **resolution = g_strsplit (str, "x", 3);
             if (resolution[0] && resolution[1]) {
               g_debug ("HLS stream width: %s, height: %s", resolution[0], resolution[1]);
-              gtuber_stream_set_width (bstream, atoi (resolution[0]));
-              gtuber_stream_set_height (bstream, atoi (resolution[1]));
+              gtuber_stream_set_width (bstream, g_ascii_strtoull (resolution[0], NULL, 10));
+              gtuber_stream_set_height (bstream, g_ascii_strtoull (resolution[1], NULL, 10));
             }
             g_strfreev (resolution);
             break;

--- a/utils/youtube/gtuber-utils-youtube.c
+++ b/utils/youtube/gtuber-utils-youtube.c
@@ -171,7 +171,8 @@ gtuber_utils_youtube_insert_chapters_from_description (GtuberMediaInfo *info,
           && (chapter_strv[1])[1] == ' '))
         offset = 2;
 
-      g_debug ("Inserting YT chapter, %lu: %s", total, chapter_strv[1] + offset);
+      g_debug ("Inserting YT chapter, %" G_GUINT64_FORMAT ": %s",
+          total, chapter_strv[1] + offset);
       gtuber_media_info_insert_chapter (info, total, chapter_strv[1] + offset);
 
       /* Inserted something, break on next non-chapter string */


### PR DESCRIPTION
Some small fixes for bugs detected when building `gtuber` on Windows OS. With this I am able to successfully build and run `gtuber` lib (including GStreamer plugin) on Windows.