### PR TITLE
Drop website "parse_data" vfunc

### DIFF
--- a/gtuber/gtuber-website.c
+++ b/gtuber/gtuber-website.c
@@ -49,8 +49,6 @@ static GtuberFlow gtuber_website_create_request (GtuberWebsite *self,
     GtuberMediaInfo *info, SoupMessage **msg, GError **error);
 static GtuberFlow gtuber_website_read_response (GtuberWebsite *self,
     SoupMessage *msg, GError **error);
-static GtuberFlow gtuber_website_parse_data (GtuberWebsite *self,
-    gchar *data, GtuberMediaInfo *info, GError **error);
 static GtuberFlow gtuber_website_parse_input_stream (GtuberWebsite *self,
     GInputStream *stream, GtuberMediaInfo *info, GError **error);
 static GtuberFlow gtuber_website_set_user_req_headers (GtuberWebsite *self,
@@ -70,11 +68,9 @@ gtuber_website_class_init (GtuberWebsiteClass *klass)
   gobject_class->dispose = gtuber_website_dispose;
   gobject_class->finalize = gtuber_website_finalize;
 
-  website_class->handles_input_stream = FALSE;
   website_class->prepare = gtuber_website_prepare;
   website_class->create_request = gtuber_website_create_request;
   website_class->read_response = gtuber_website_read_response;
-  website_class->parse_data = gtuber_website_parse_data;
   website_class->parse_input_stream = gtuber_website_parse_input_stream;
   website_class->set_user_req_headers = gtuber_website_set_user_req_headers;
 }
@@ -162,13 +158,6 @@ gtuber_website_create_request (GtuberWebsite *self,
 static GtuberFlow
 gtuber_website_read_response (GtuberWebsite *self,
     SoupMessage *msg, GError **error)
-{
-  return (*error == NULL) ? GTUBER_FLOW_OK : GTUBER_FLOW_ERROR;
-}
-
-static GtuberFlow
-gtuber_website_parse_data (GtuberWebsite *self,
-    gchar *data, GtuberMediaInfo *info, GError **error)
 {
   return (*error == NULL) ? GTUBER_FLOW_OK : GTUBER_FLOW_ERROR;
 }

--- a/gtuber/gtuber-website.h
+++ b/gtuber/gtuber-website.h
@@ -181,14 +181,11 @@ struct _GtuberWebsite
 /**
  * GtuberWebsiteClass:
  * @parent_class: The object class structure.
- * @handles_input_stream: When set to %TRUE, parse_input_stream() will be called
- *   at parsing stage otherwise parse_response() will be used.
  * @prepare: If plugin needs to do some post init blocking IO (like reading cache)
  *   before it can be used, this is a good place to do so.
  * @create_request: Create and pass #SoupMessage to send.
  * @read_response: Use to check #SoupStatus and response #SoupMessageHeaders
  *   from send #SoupMessage.
- * @parse_data: Read data of response body and fill #GtuberMediaInfo.
  * @parse_input_stream: Read #GInputStream and fill #GtuberMediaInfo.
  * @set_user_req_headers: Set request headers for user. Default implementation
  *   will set them from last #SoupMessage, skipping some common and invalid ones.
@@ -196,8 +193,6 @@ struct _GtuberWebsite
 struct _GtuberWebsiteClass
 {
   GObjectClass parent_class;
-
-  gboolean handles_input_stream;
 
   void (* prepare) (GtuberWebsite *website);
 
@@ -209,11 +204,6 @@ struct _GtuberWebsiteClass
   GtuberFlow (* read_response) (GtuberWebsite *website,
                                 SoupMessage   *msg,
                                 GError       **error);
-
-  GtuberFlow (* parse_data) (GtuberWebsite   *website,
-                             gchar           *data,
-                             GtuberMediaInfo *info,
-                             GError         **error);
 
   GtuberFlow (* parse_input_stream) (GtuberWebsite   *website,
                                      GInputStream    *stream,

--- a/plugins/bilibili/gtuber-bilibili.c
+++ b/plugins/bilibili/gtuber-bilibili.c
@@ -335,7 +335,6 @@ gtuber_bilibili_class_init (GtuberBilibiliClass *klass)
 
   gobject_class->finalize = gtuber_bilibili_finalize;
 
-  website_class->handles_input_stream = TRUE;
   website_class->create_request = gtuber_bilibili_create_request;
   website_class->parse_input_stream = gtuber_bilibili_parse_input_stream;
 }

--- a/plugins/crunchyroll-beta/gtuber-crunchyroll-beta.c
+++ b/plugins/crunchyroll-beta/gtuber-crunchyroll-beta.c
@@ -666,7 +666,6 @@ gtuber_crunchyroll_beta_class_init (GtuberCrunchyrollBetaClass *klass)
 
   gobject_class->finalize = gtuber_crunchyroll_beta_finalize;
 
-  website_class->handles_input_stream = TRUE;
   website_class->prepare = gtuber_crunchyroll_beta_prepare;
   website_class->create_request = gtuber_crunchyroll_beta_create_request;
   website_class->parse_input_stream = gtuber_crunchyroll_beta_parse_input_stream;

--- a/plugins/crunchyroll-beta/gtuber-crunchyroll-beta.c
+++ b/plugins/crunchyroll-beta/gtuber-crunchyroll-beta.c
@@ -454,10 +454,8 @@ gtuber_crunchyroll_beta_prepare (GtuberWebsite *website)
   self->policy_response = gtuber_crunchyroll_beta_cache_read ("policy_response");
 
   /* If we restored cached policy, skip steps to get it */
-  if (self->policy_response && !etp_rt_changed) {
-    GTUBER_WEBSITE_GET_CLASS (self)->handles_input_stream = TRUE;
+  if (self->policy_response && !etp_rt_changed)
     self->step = CRUNCHYROLL_BETA_GET_POLICY_RESPONSE + 1;
-  }
 
   ext_lang = gtuber_utils_common_obtain_uri_id_from_paths (
       gtuber_website_get_uri (website), NULL, "/", NULL);
@@ -536,19 +534,21 @@ gtuber_crunchyroll_beta_create_request (GtuberWebsite *website,
       : GTUBER_FLOW_OK;
 }
 
-static GtuberFlow
-gtuber_crunchyroll_beta_parse_data (GtuberWebsite *website,
-    gchar *data, GtuberMediaInfo *info, GError **error)
+static void
+parse_auth_token (GtuberCrunchyrollBeta *self, GInputStream *stream, GError **error)
 {
-  GtuberCrunchyrollBeta *self = GTUBER_CRUNCHYROLL_BETA (website);
   JsonParser *parser;
   xmlDoc *doc;
-  gchar *json_str;
+  gchar *data, *json_str;
 
-  g_debug ("Parse step: %u", self->step);
+  if (!(data = gtuber_utils_common_input_stream_to_data (stream, error)))
+    return;
 
-  if (!(doc = gtuber_utils_xml_load_html_from_data (data, error)))
-    return GTUBER_FLOW_ERROR;
+  doc = gtuber_utils_xml_load_html_from_data (data, error);
+  g_free (data);
+
+  if (!doc)
+    return;
 
   json_str = gtuber_utils_xml_obtain_json_in_node (doc, "__APP_CONFIG__");
   xmlFreeDoc (doc);
@@ -557,7 +557,7 @@ gtuber_crunchyroll_beta_parse_data (GtuberWebsite *website,
     g_set_error (error, GTUBER_WEBSITE_ERROR,
         GTUBER_WEBSITE_ERROR_PARSE_FAILED,
         "Could not extract Crunchyroll JSON data");
-    return GTUBER_FLOW_ERROR;
+    return;
   }
 
   parser = json_parser_new ();
@@ -590,14 +590,6 @@ gtuber_crunchyroll_beta_parse_data (GtuberWebsite *website,
 
   g_object_unref (parser);
   g_free (json_str);
-
-  /* We prefer to use GInputStream for remaining requests */
-  GTUBER_WEBSITE_GET_CLASS (self)->handles_input_stream = TRUE;
-  self->step++;
-
-  return (*error)
-      ? GTUBER_FLOW_ERROR
-      : GTUBER_FLOW_RESTART;
 }
 
 static GtuberFlow
@@ -619,6 +611,11 @@ gtuber_crunchyroll_beta_parse_input_stream (GtuberWebsite *website,
   }
 
   /* FIXME: DASH support */
+
+  if (self->step == CRUNCHYROLL_BETA_GET_AUTH_TOKEN) {
+    parse_auth_token (self, stream, error);
+    goto finish_step;
+  }
 
   parser = json_parser_new ();
 
@@ -651,6 +648,7 @@ gtuber_crunchyroll_beta_parse_input_stream (GtuberWebsite *website,
   g_object_unref (reader);
   g_object_unref (parser);
 
+finish_step:
   if (*error)
     return GTUBER_FLOW_ERROR;
 
@@ -668,9 +666,9 @@ gtuber_crunchyroll_beta_class_init (GtuberCrunchyrollBetaClass *klass)
 
   gobject_class->finalize = gtuber_crunchyroll_beta_finalize;
 
+  website_class->handles_input_stream = TRUE;
   website_class->prepare = gtuber_crunchyroll_beta_prepare;
   website_class->create_request = gtuber_crunchyroll_beta_create_request;
-  website_class->parse_data = gtuber_crunchyroll_beta_parse_data;
   website_class->parse_input_stream = gtuber_crunchyroll_beta_parse_input_stream;
 }
 

--- a/plugins/invidious/gtuber-invidious.c
+++ b/plugins/invidious/gtuber-invidious.c
@@ -307,7 +307,6 @@ gtuber_invidious_class_init (GtuberInvidiousClass *klass)
 
   gobject_class->finalize = gtuber_invidious_finalize;
 
-  website_class->handles_input_stream = TRUE;
   website_class->create_request = gtuber_invidious_create_request;
   website_class->parse_input_stream = gtuber_invidious_parse_input_stream;
 }

--- a/plugins/lbry/gtuber-lbry.c
+++ b/plugins/lbry/gtuber-lbry.c
@@ -361,7 +361,6 @@ gtuber_lbry_class_init (GtuberLbryClass *klass)
 
   gobject_class->finalize = gtuber_lbry_finalize;
 
-  website_class->handles_input_stream = TRUE;
   website_class->create_request = gtuber_lbry_create_request;
   website_class->read_response = gtuber_lbry_read_response;
   website_class->parse_input_stream = gtuber_lbry_parse_input_stream;

--- a/plugins/niconico/gtuber-niconico.c
+++ b/plugins/niconico/gtuber-niconico.c
@@ -452,7 +452,6 @@ gtuber_niconico_class_init (GtuberNiconicoClass *klass)
 
   gobject_class->finalize = gtuber_niconico_finalize;
 
-  website_class->handles_input_stream = TRUE;
   website_class->create_request = gtuber_niconico_create_request;
   website_class->parse_input_stream = gtuber_niconico_parse_input_stream;
 }

--- a/plugins/niconico/gtuber-niconico.c
+++ b/plugins/niconico/gtuber-niconico.c
@@ -337,37 +337,38 @@ have_msg:
 }
 
 static GtuberFlow
-gtuber_niconico_parse_data (GtuberWebsite *website,
-    gchar *data, GtuberMediaInfo *info, GError **error)
-{
-  GtuberNiconico *self = GTUBER_NICONICO (website);
-  xmlDoc *doc;
-
-  if (!(doc = gtuber_utils_xml_load_html_from_data (data, error)))
-    return GTUBER_FLOW_ERROR;
-
-  self->api_data = g_strdup (gtuber_utils_xml_get_property_content (doc, "data-api-data"));
-  xmlFreeDoc (doc);
-
-  if (!self->api_data) {
-    g_set_error (error, GTUBER_WEBSITE_ERROR,
-        GTUBER_WEBSITE_ERROR_PARSE_FAILED,
-        "Could not extract niconico API data");
-    return GTUBER_FLOW_ERROR;
-  }
-
-  /* We prefer to use GInputStream for remaining requests */
-  GTUBER_WEBSITE_GET_CLASS (self)->handles_input_stream = TRUE;
-
-  return GTUBER_FLOW_RESTART;
-}
-
-static GtuberFlow
 gtuber_niconico_parse_input_stream (GtuberWebsite *website,
     GInputStream *stream, GtuberMediaInfo *info, GError **error)
 {
   GtuberNiconico *self = GTUBER_NICONICO (website);
   JsonParser *parser;
+
+  /* Extract API data from XML first */
+  if (!self->api_data) {
+    xmlDoc *doc;
+    gchar *data;
+
+    if (!(data = gtuber_utils_common_input_stream_to_data (stream, error)))
+      return GTUBER_FLOW_ERROR;
+
+    doc = gtuber_utils_xml_load_html_from_data (data, error);
+    g_free (data);
+
+    if (!doc)
+      return GTUBER_FLOW_ERROR;
+
+    self->api_data = g_strdup (gtuber_utils_xml_get_property_content (doc, "data-api-data"));
+    xmlFreeDoc (doc);
+
+    if (!self->api_data) {
+      g_set_error (error, GTUBER_WEBSITE_ERROR,
+          GTUBER_WEBSITE_ERROR_PARSE_FAILED,
+          "Could not extract niconico API data");
+      return GTUBER_FLOW_ERROR;
+    }
+
+    return GTUBER_FLOW_RESTART;
+  }
 
   if (self->hls_uri) {
     if (gtuber_utils_common_parse_hls_input_stream_with_base_uri (stream,
@@ -451,9 +452,8 @@ gtuber_niconico_class_init (GtuberNiconicoClass *klass)
 
   gobject_class->finalize = gtuber_niconico_finalize;
 
-  website_class->handles_input_stream = FALSE;
+  website_class->handles_input_stream = TRUE;
   website_class->create_request = gtuber_niconico_create_request;
-  website_class->parse_data = gtuber_niconico_parse_data;
   website_class->parse_input_stream = gtuber_niconico_parse_input_stream;
 }
 

--- a/plugins/peertube/gtuber-peertube.c
+++ b/plugins/peertube/gtuber-peertube.c
@@ -204,7 +204,6 @@ gtuber_peertube_class_init (GtuberPeertubeClass *klass)
 
   gobject_class->finalize = gtuber_peertube_finalize;
 
-  website_class->handles_input_stream = TRUE;
   website_class->create_request = gtuber_peertube_create_request;
   website_class->parse_input_stream = gtuber_peertube_parse_input_stream;
 }

--- a/plugins/piped/gtuber-piped.c
+++ b/plugins/piped/gtuber-piped.c
@@ -302,7 +302,6 @@ gtuber_piped_class_init (GtuberPipedClass *klass)
 
   gobject_class->finalize = gtuber_piped_finalize;
 
-  website_class->handles_input_stream = TRUE;
   website_class->create_request = gtuber_piped_create_request;
   website_class->parse_input_stream = gtuber_piped_parse_input_stream;
 }

--- a/plugins/reddit/gtuber-reddit.c
+++ b/plugins/reddit/gtuber-reddit.c
@@ -300,7 +300,6 @@ gtuber_reddit_class_init (GtuberRedditClass *klass)
 
   gobject_class->finalize = gtuber_reddit_finalize;
 
-  website_class->handles_input_stream = TRUE;
   website_class->prepare = gtuber_reddit_prepare;
   website_class->create_request = gtuber_reddit_create_request;
   website_class->read_response = gtuber_reddit_read_response;

--- a/plugins/twitch/gtuber-twitch.c
+++ b/plugins/twitch/gtuber-twitch.c
@@ -557,7 +557,6 @@ gtuber_twitch_class_init (GtuberTwitchClass *klass)
 
   gobject_class->finalize = gtuber_twitch_finalize;
 
-  website_class->handles_input_stream = TRUE;
   website_class->create_request = gtuber_twitch_create_request;
   website_class->parse_input_stream = gtuber_twitch_parse_input_stream;
   website_class->set_user_req_headers = gtuber_twitch_set_user_req_headers;

--- a/plugins/youtube/gtuber-youtube.c
+++ b/plugins/youtube/gtuber-youtube.c
@@ -415,7 +415,6 @@ gtuber_youtube_class_init (GtuberYoutubeClass *klass)
 
   gobject_class->finalize = gtuber_youtube_finalize;
 
-  website_class->handles_input_stream = TRUE;
   website_class->prepare = gtuber_youtube_prepare;
   website_class->create_request = gtuber_youtube_create_request;
   website_class->parse_input_stream = gtuber_youtube_parse_input_stream;

--- a/utils/common/gtuber-utils-common.c
+++ b/utils/common/gtuber-utils-common.c
@@ -274,6 +274,29 @@ gtuber_utils_common_replace_uri_source (const gchar *uri_str, const gchar *src_u
   return mod_uri_str;
 }
 
+gchar *
+gtuber_utils_common_input_stream_to_data (GInputStream *stream, GError **error)
+{
+  GOutputStream *ostream;
+  gchar *data = NULL;
+
+  ostream = g_memory_output_stream_new_resizable ();
+  if (g_output_stream_splice (ostream, stream,
+      G_OUTPUT_STREAM_SPLICE_CLOSE_SOURCE | G_OUTPUT_STREAM_SPLICE_CLOSE_TARGET,
+      NULL, error) != -1) {
+    data = g_memory_output_stream_steal_data (G_MEMORY_OUTPUT_STREAM (ostream));
+  }
+  g_object_unref (ostream);
+
+  if (!data && *error == NULL) {
+    g_set_error (error, GTUBER_WEBSITE_ERROR,
+        GTUBER_WEBSITE_ERROR_PARSE_FAILED,
+        "Could not convert input stream to data");
+  }
+
+  return data;
+}
+
 /**
  * gtuber_utils_common_msg_take_request:
  * @msg: a #SoupMessage

--- a/utils/common/gtuber-utils-common.h
+++ b/utils/common/gtuber-utils-common.h
@@ -40,6 +40,8 @@ gchar *              gtuber_utils_common_obtain_uri_source                    (G
 
 gchar *              gtuber_utils_common_replace_uri_source                   (const gchar *uri_str, const gchar *src_uri_str);
 
+gchar *              gtuber_utils_common_input_stream_to_data                 (GInputStream *stream, GError **error);
+
 void                 gtuber_utils_common_msg_take_request                     (SoupMessage *msg, const gchar *content_type, gchar *req_body);
 
 GtuberStreamMimeType gtuber_utils_common_get_mime_type_from_string            (const gchar *string);


### PR DESCRIPTION
Having websites calling one function or another for reading data depending on
additional boolean property value makes things unnecessary complicated.

Remove this in favor of using input streams all around and use a convenience method
that converts input stream into data for plugins that need to have it as complete prior.