### PR TITLE
piped: Support user specified hosts and API endpoints

### DIFF
--- a/plugins/piped/README.md
+++ b/plugins/piped/README.md
@@ -1,0 +1,10 @@
+## Piped
+
+By default plugin only supports [piped.kavin.rocks](https://piped.kavin.rocks/) instance and works using it's corresponding API endpoint.
+
+Additional hosts can be put in `piped_hosts` file in `gtuber` config directory.
+If you want to use custom hosts, you must additionally create `piped_api_hosts` config file.
+Put a list of API hosts there. It is expected that both frontend and API operate on different
+subdomain of the same domain. That is how plugin will match video URI with API host to use.
+
+List of available instances can be found here: [https://piped-instances.kavin.rocks/](https://piped-instances.kavin.rocks/)

--- a/plugins/piped/gtuber-piped.c
+++ b/plugins/piped/gtuber-piped.c
@@ -33,12 +33,10 @@ typedef enum
 
 GTUBER_WEBSITE_PLUGIN_EXPORT_HOSTS (
   "piped.kavin.rocks",
-  "piped.silkky.cloud",
   NULL
 )
 static const gchar *piped_apis[] = {
   "pipedapi.kavin.rocks",
-  "api.piped.silkky.cloud",
   NULL
 };
 

--- a/utils/common/gtuber-utils-common.c
+++ b/utils/common/gtuber-utils-common.c
@@ -275,6 +275,23 @@ gtuber_utils_common_replace_uri_source (const gchar *uri_str, const gchar *src_u
 }
 
 gchar *
+gtuber_utils_common_obtain_domain (const gchar *host)
+{
+  gchar **parts, *domain = NULL;
+  guint n_parts;
+
+  parts = g_strsplit (host, ".", 0);
+  n_parts = g_strv_length (parts);
+
+  if (n_parts >= 3)
+    domain = g_strjoin (".", parts[n_parts - 2], parts[n_parts - 1], NULL);
+
+  g_strfreev (parts);
+
+  return domain;
+}
+
+gchar *
 gtuber_utils_common_input_stream_to_data (GInputStream *stream, GError **error)
 {
   GOutputStream *ostream;

--- a/utils/common/gtuber-utils-common.h
+++ b/utils/common/gtuber-utils-common.h
@@ -40,6 +40,8 @@ gchar *              gtuber_utils_common_obtain_uri_source                    (G
 
 gchar *              gtuber_utils_common_replace_uri_source                   (const gchar *uri_str, const gchar *src_uri_str);
 
+gchar *              gtuber_utils_common_obtain_domain                        (const gchar *host);
+
 gchar *              gtuber_utils_common_input_stream_to_data                 (GInputStream *stream, GError **error);
 
 void                 gtuber_utils_common_msg_take_request                     (SoupMessage *msg, const gchar *content_type, gchar *req_body);


### PR DESCRIPTION
Brief instruction how to configure can be found in piped plugin directory when browsing this git project.

Closes #35