### PR TITLE
Add reconfigure flow feature

### DIFF
--- a/gtuber/gtuber-enums.h
+++ b/gtuber/gtuber-enums.h
@@ -136,13 +136,15 @@ typedef enum
  * GtuberFlow:
  * @GTUBER_FLOW_OK: continue parsing.
  * @GTUBER_FLOW_ERROR: give up.
- * @GTUBER_FLOW_RESTART: start from beginning.
+ * @GTUBER_FLOW_RESTART: start from first step again.
+ * @GTUBER_FLOW_RECONFIGURE: change URI and do a clean restart.
  */
 typedef enum
 {
   GTUBER_FLOW_OK = 0,
   GTUBER_FLOW_ERROR,
   GTUBER_FLOW_RESTART,
+  GTUBER_FLOW_RECONFIGURE,
 } GtuberFlow;
 
 G_END_DECLS

--- a/gtuber/gtuber-website-private.h
+++ b/gtuber/gtuber-website-private.h
@@ -25,7 +25,4 @@ G_BEGIN_DECLS
 
 typedef struct _GtuberWebsitePrivate GtuberWebsitePrivate;
 
-G_GNUC_INTERNAL
-void gtuber_website_set_uri (GtuberWebsite *website, GUri *uri);
-
 G_END_DECLS

--- a/gtuber/gtuber-website.c
+++ b/gtuber/gtuber-website.c
@@ -199,20 +199,6 @@ gtuber_website_set_user_req_headers (GtuberWebsite *self,
   return GTUBER_FLOW_OK;
 }
 
-void
-gtuber_website_set_uri (GtuberWebsite *self, GUri *uri)
-{
-  GtuberWebsitePrivate *priv = gtuber_website_get_instance_private (self);
-
-  if (priv->uri)
-    g_uri_unref (priv->uri);
-
-  priv->uri = g_uri_ref (uri);
-
-  g_free (priv->uri_str);
-  priv->uri_str = g_uri_to_string (priv->uri);
-}
-
 /**
  * gtuber_website_get_uri:
  * @website: a #GtuberWebsite
@@ -232,6 +218,34 @@ gtuber_website_get_uri (GtuberWebsite *self)
 }
 
 /**
+ * gtuber_website_set_uri:
+ * @website: a #GtuberWebsite
+ * @uri: a media source URI
+ *
+ * Sets new URI for handling. URI cannot be %NULL.
+ *
+ * This is mainly useful together with reconfigure flow event.
+ */
+void
+gtuber_website_set_uri (GtuberWebsite *self, GUri *uri)
+{
+  GtuberWebsitePrivate *priv;
+
+  g_return_if_fail (GTUBER_IS_WEBSITE (self));
+  g_return_if_fail (uri != NULL);
+
+  priv = gtuber_website_get_instance_private (self);
+
+  if (priv->uri)
+    g_uri_unref (priv->uri);
+
+  priv->uri = g_uri_ref (uri);
+
+  g_free (priv->uri_str);
+  priv->uri_str = g_uri_to_string (priv->uri);
+}
+
+/**
  * gtuber_website_get_uri_string:
  * @website: a #GtuberWebsite
  *
@@ -247,6 +261,36 @@ gtuber_website_get_uri_string (GtuberWebsite *self)
   priv = gtuber_website_get_instance_private (self);
 
   return priv->uri_str;
+}
+
+/**
+ * gtuber_website_set_uri_from_string:
+ * @website: a #GtuberWebsite
+ * @uri_str: a media source URI as string
+ * @error: (nullable): return location for a #GError, or %NULL
+ *
+ * Sets URI from string for handling.
+ *
+ * This is mainly useful together with reconfigure flow event.
+ */
+gboolean
+gtuber_website_set_uri_from_string (GtuberWebsite *self,
+    const gchar *uri_str, GError **error)
+{
+  GUri *uri;
+  gboolean success;
+
+  g_return_val_if_fail (GTUBER_IS_WEBSITE (self), FALSE);
+
+  uri = g_uri_parse (uri_str, G_URI_FLAGS_ENCODED, error);
+  success = (uri && *error == NULL);
+
+  if (success) {
+    gtuber_website_set_uri (self, uri);
+    g_uri_unref (uri);
+  }
+
+  return success;
 }
 
 /**

--- a/gtuber/gtuber-website.h
+++ b/gtuber/gtuber-website.h
@@ -220,7 +220,11 @@ GType           gtuber_website_get_type              (void);
 
 GUri *          gtuber_website_get_uri               (GtuberWebsite *website);
 
+void            gtuber_website_set_uri               (GtuberWebsite *website, GUri *uri);
+
 const gchar *   gtuber_website_get_uri_string        (GtuberWebsite *website);
+
+gboolean        gtuber_website_set_uri_from_string   (GtuberWebsite *website, const gchar *uri_str, GError **error);
 
 gboolean        gtuber_website_get_use_http          (GtuberWebsite *website);
 


### PR DESCRIPTION
Useful when website might have embedded video from a different service.
In this case some other plugin might be able to handle it, thus this convenient
method of switching between plugins in the middle of parsing is added.

Closes #40 