### PR TITLE
gst: Automatically use adaptivedemux2 elements

### DIFF
--- a/gst/gst-gtuber/gstgtuberadaptivebin.c
+++ b/gst/gst-gtuber/gstgtuberadaptivebin.c
@@ -96,8 +96,8 @@ gst_gtuber_adaptive_bin_set_property (GObject *object, guint prop_id,
       break;
     case PROP_TARGET_BITRATE:
       self->target_bitrate = g_value_get_uint (value);
-      g_object_set (self->demuxer,
-          "connection-speed", self->target_bitrate, NULL);
+      if (self->demuxer)
+        g_object_set (self->demuxer, "connection-speed", self->target_bitrate, NULL);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);

--- a/gst/gst-gtuber/gstgtuberadaptivebin.c
+++ b/gst/gst-gtuber/gstgtuberadaptivebin.c
@@ -44,47 +44,6 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 G_DEFINE_TYPE_WITH_CODE (GstGtuberAdaptiveBin,
     gst_gtuber_adaptive_bin, GST_TYPE_GTUBER_BIN, NULL);
 
-/* GObject */
-static void gst_gtuber_adaptive_bin_constructed (GObject* object);
-static void gst_gtuber_adaptive_bin_set_property (GObject *object,
-    guint prop_id, const GValue *value, GParamSpec *pspec);
-static void gst_gtuber_adaptive_bin_get_property (GObject *object,
-    guint prop_id, GValue *value, GParamSpec *pspec);
-
-/* GstElement */
-static GstStateChangeReturn gst_gtuber_adaptive_bin_change_state (
-    GstElement *element, GstStateChange transition);
-static void demuxer_no_more_pads_cb (GstElement *element,
-    GstGtuberAdaptiveBin *self);
-
-static void
-gst_gtuber_adaptive_bin_class_init (GstGtuberAdaptiveBinClass *klass)
-{
-  GObjectClass *gobject_class = (GObjectClass *) klass;
-  GstElementClass *gstelement_class = (GstElementClass *) klass;
-
-  GST_DEBUG_CATEGORY_INIT (gst_gtuber_adaptive_bin_debug, "gtuberadaptivebin", 0,
-      "Gtuber Adaptive Bin");
-
-  gobject_class->constructed = gst_gtuber_adaptive_bin_constructed;
-  gobject_class->set_property = gst_gtuber_adaptive_bin_set_property;
-  gobject_class->get_property = gst_gtuber_adaptive_bin_get_property;
-
-  param_specs[PROP_INITIAL_BITRATE] = g_param_spec_uint ("initial-bitrate",
-      "Initial Bitrate", "Initial startup bitrate in kbps (0 = same as target-bitrate)",
-       0, G_MAXUINT, DEFAULT_INITIAL_BITRATE,
-       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
-
-  param_specs[PROP_TARGET_BITRATE] = g_param_spec_uint ("target-bitrate",
-      "Target Bitrate", "Target playback bitrate in kbps (0 = auto, based on download speed)",
-       0, G_MAXUINT, DEFAULT_TARGET_BITRATE,
-       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
-
-  g_object_class_install_properties (gobject_class, PROP_LAST, param_specs);
-
-  gstelement_class->change_state = gst_gtuber_adaptive_bin_change_state;
-}
-
 static void
 gst_gtuber_adaptive_bin_init (GstGtuberAdaptiveBin *self)
 {
@@ -351,4 +310,32 @@ gst_gtuber_adaptive_bin_change_state (GstElement *element, GstStateChange transi
   }
 
   return ret;
+}
+
+static void
+gst_gtuber_adaptive_bin_class_init (GstGtuberAdaptiveBinClass *klass)
+{
+  GObjectClass *gobject_class = (GObjectClass *) klass;
+  GstElementClass *gstelement_class = (GstElementClass *) klass;
+
+  GST_DEBUG_CATEGORY_INIT (gst_gtuber_adaptive_bin_debug, "gtuberadaptivebin", 0,
+      "Gtuber Adaptive Bin");
+
+  gobject_class->constructed = gst_gtuber_adaptive_bin_constructed;
+  gobject_class->set_property = gst_gtuber_adaptive_bin_set_property;
+  gobject_class->get_property = gst_gtuber_adaptive_bin_get_property;
+
+  param_specs[PROP_INITIAL_BITRATE] = g_param_spec_uint ("initial-bitrate",
+      "Initial Bitrate", "Initial startup bitrate in kbps (0 = same as target-bitrate)",
+       0, G_MAXUINT, DEFAULT_INITIAL_BITRATE,
+       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+  param_specs[PROP_TARGET_BITRATE] = g_param_spec_uint ("target-bitrate",
+      "Target Bitrate", "Target playback bitrate in kbps (0 = auto, based on download speed)",
+       0, G_MAXUINT, DEFAULT_TARGET_BITRATE,
+       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (gobject_class, PROP_LAST, param_specs);
+
+  gstelement_class->change_state = gst_gtuber_adaptive_bin_change_state;
 }

--- a/gst/gst-gtuber/gstgtuberadaptivebin.c
+++ b/gst/gst-gtuber/gstgtuberadaptivebin.c
@@ -35,6 +35,19 @@ enum
   PROP_LAST
 };
 
+static GstStaticPadTemplate videosrc_template = GST_STATIC_PAD_TEMPLATE ("video_%02u",
+    GST_PAD_SRC,
+    GST_PAD_SOMETIMES,
+    GST_STATIC_CAPS_ANY);
+static GstStaticPadTemplate audiosrc_template = GST_STATIC_PAD_TEMPLATE ("audio_%02u",
+    GST_PAD_SRC,
+    GST_PAD_SOMETIMES,
+    GST_STATIC_CAPS_ANY);
+static GstStaticPadTemplate subtitlesrc_template = GST_STATIC_PAD_TEMPLATE ("subtitle_%02u",
+    GST_PAD_SRC,
+    GST_PAD_SOMETIMES,
+    GST_STATIC_CAPS_ANY);
+
 static GParamSpec *param_specs[PROP_LAST] = { NULL, };
 
 #define GST_CAT_DEFAULT gst_gtuber_adaptive_bin_debug
@@ -446,6 +459,10 @@ gst_gtuber_adaptive_bin_class_init (GstGtuberAdaptiveBinClass *klass)
 
   GST_DEBUG_CATEGORY_INIT (gst_gtuber_adaptive_bin_debug, "gtuberadaptivebin", 0,
       "Gtuber Adaptive Bin");
+
+  gst_element_class_add_static_pad_template (gstelement_class, &videosrc_template);
+  gst_element_class_add_static_pad_template (gstelement_class, &audiosrc_template);
+  gst_element_class_add_static_pad_template (gstelement_class, &subtitlesrc_template);
 
   gobject_class->constructed = gst_gtuber_adaptive_bin_constructed;
   gobject_class->set_property = gst_gtuber_adaptive_bin_set_property;

--- a/gst/gst-gtuber/gstgtuberadaptivebin.c
+++ b/gst/gst-gtuber/gstgtuberadaptivebin.c
@@ -316,7 +316,11 @@ gst_gtuber_adaptive_bin_prepare (GstGtuberAdaptiveBin *self)
   GST_GTUBER_BIN_UNLOCK (self);
 
   if ((self->demuxer = make_compatible_demuxer (self))) {
+    GObjectClass *gobject_class = G_OBJECT_GET_CLASS (self->demuxer);
     GstPad *pad;
+
+    if (g_object_class_find_property (gobject_class, "low-watermark-time"))
+      g_object_set (self->demuxer, "low-watermark-time", 3 * GST_SECOND, NULL);
 
     gst_bin_add (GST_BIN (self), self->demuxer);
 

--- a/gst/gst-gtuber/gstgtuberadaptivebin.h
+++ b/gst/gst-gtuber/gstgtuberadaptivebin.h
@@ -42,11 +42,15 @@ struct _GstGtuberAdaptiveBin
 {
   GstGtuberBin parent;
 
+  GstPad *sink_ghostpad;
+
   guint initial_bitrate;
   guint target_bitrate;
 
+  gboolean prepared;
   gboolean needs_playback_config;
 
+  const gchar *demuxer_name;
   GstElement *demuxer;
 };
 

--- a/gst/gst-gtuber/gstgtuberbin.c
+++ b/gst/gst-gtuber/gstgtuberbin.c
@@ -30,31 +30,6 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_DEFAULT);
 #define parent_class gst_gtuber_bin_parent_class
 G_DEFINE_TYPE_WITH_CODE (GstGtuberBin, gst_gtuber_bin, GST_TYPE_BIN, NULL);
 
-/* GObject */
-static void gst_gtuber_bin_finalize (GObject *object);
-
-/* GstElement */
-static GstStateChangeReturn gst_gtuber_bin_change_state (
-    GstElement *element, GstStateChange transition);
-
-/* GstBin */
-static void gst_gtuber_bin_deep_element_added (GstBin *bin,
-    GstBin *sub_bin, GstElement *child);
-
-static void
-gst_gtuber_bin_class_init (GstGtuberBinClass *klass)
-{
-  GObjectClass *gobject_class = (GObjectClass *) klass;
-  GstBinClass *gstbin_class = (GstBinClass *) klass;
-  GstElementClass *gstelement_class = (GstElementClass *) klass;
-
-  GST_DEBUG_CATEGORY_INIT (gst_gtuber_bin_debug, "gtuberbin", 0, "Gtuber Bin");
-
-  gobject_class->finalize = gst_gtuber_bin_finalize;
-  gstbin_class->deep_element_added = gst_gtuber_bin_deep_element_added;
-  gstelement_class->change_state = gst_gtuber_bin_change_state;
-}
-
 static void
 gst_gtuber_bin_init (GstGtuberBin *self)
 {
@@ -284,4 +259,18 @@ gst_gtuber_bin_sink_event (GstPad *pad, GstObject *parent, GstEvent *event)
   }
 
   return gst_pad_event_default (pad, parent, event);
+}
+
+static void
+gst_gtuber_bin_class_init (GstGtuberBinClass *klass)
+{
+  GObjectClass *gobject_class = (GObjectClass *) klass;
+  GstBinClass *gstbin_class = (GstBinClass *) klass;
+  GstElementClass *gstelement_class = (GstElementClass *) klass;
+
+  GST_DEBUG_CATEGORY_INIT (gst_gtuber_bin_debug, "gtuberbin", 0, "Gtuber Bin");
+
+  gobject_class->finalize = gst_gtuber_bin_finalize;
+  gstbin_class->deep_element_added = gst_gtuber_bin_deep_element_added;
+  gstelement_class->change_state = gst_gtuber_bin_change_state;
 }

--- a/gst/gst-gtuber/gstgtuberdashdemux.c
+++ b/gst/gst-gtuber/gstgtuberdashdemux.c
@@ -32,19 +32,6 @@ static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_ALWAYS,
     GST_STATIC_CAPS ("application/dash+xml, source=(string)gtuber"));
 
-static GstStaticPadTemplate videosrc_template = GST_STATIC_PAD_TEMPLATE ("video_%02u",
-    GST_PAD_SRC,
-    GST_PAD_SOMETIMES,
-    GST_STATIC_CAPS_ANY);
-static GstStaticPadTemplate audiosrc_template = GST_STATIC_PAD_TEMPLATE ("audio_%02u",
-    GST_PAD_SRC,
-    GST_PAD_SOMETIMES,
-    GST_STATIC_CAPS_ANY);
-static GstStaticPadTemplate subtitlesrc_template = GST_STATIC_PAD_TEMPLATE ("subtitle_%02u",
-    GST_PAD_SRC,
-    GST_PAD_SOMETIMES,
-    GST_STATIC_CAPS_ANY);
-
 #define parent_class gst_gtuber_dash_demux_parent_class
 G_DEFINE_TYPE_WITH_CODE (GstGtuberDashDemux, gst_gtuber_dash_demux,
     GST_TYPE_GTUBER_ADAPTIVE_BIN, NULL);
@@ -65,9 +52,6 @@ gst_gtuber_dash_demux_class_init (GstGtuberDashDemuxClass *klass)
       "Gtuber DASH demux");
 
   gst_element_class_add_static_pad_template (gstelement_class, &sink_template);
-  gst_element_class_add_static_pad_template (gstelement_class, &videosrc_template);
-  gst_element_class_add_static_pad_template (gstelement_class, &audiosrc_template);
-  gst_element_class_add_static_pad_template (gstelement_class, &subtitlesrc_template);
 
   gst_element_class_set_static_metadata (gstelement_class, "Gtuber DASH demuxer",
       "Codec/Demuxer/Adaptive",

--- a/gst/gst-gtuber/gstgtuberdashdemux.c
+++ b/gst/gst-gtuber/gstgtuberdashdemux.c
@@ -51,8 +51,20 @@ G_DEFINE_TYPE_WITH_CODE (GstGtuberDashDemux, gst_gtuber_dash_demux,
 GST_ELEMENT_REGISTER_DEFINE_WITH_CODE (gtuberdashdemux, "gtuberdashdemux",
     GST_RANK_PRIMARY + 10, GST_TYPE_GTUBER_DASH_DEMUX, gst_gtuber_element_init (plugin));
 
-/* GObject */
-static void gst_gtuber_dash_demux_constructed (GObject* object);
+static void
+gst_gtuber_dash_demux_init (GstGtuberDashDemux *self)
+{
+}
+
+static void
+gst_gtuber_dash_demux_constructed (GObject* object)
+{
+  GstGtuberAdaptiveBin *adaptive_bin = GST_GTUBER_ADAPTIVE_BIN_CAST (object);
+
+  adaptive_bin->demuxer = gst_element_factory_make ("dashdemux", NULL);
+
+  GST_CALL_PARENT (G_OBJECT_CLASS, constructed, (object));
+}
 
 static void
 gst_gtuber_dash_demux_class_init (GstGtuberDashDemuxClass *klass)
@@ -74,19 +86,4 @@ gst_gtuber_dash_demux_class_init (GstGtuberDashDemuxClass *klass)
       "Codec/Demuxer/Adaptive",
       "Demuxer for Gtuber DASH data",
       "Rafał Dzięgiel <rafostar.github@gmail.com>");
-}
-
-static void
-gst_gtuber_dash_demux_init (GstGtuberDashDemux *self)
-{
-}
-
-static void
-gst_gtuber_dash_demux_constructed (GObject* object)
-{
-  GstGtuberAdaptiveBin *adaptive_bin = GST_GTUBER_ADAPTIVE_BIN_CAST (object);
-
-  adaptive_bin->demuxer = gst_element_factory_make ("dashdemux", NULL);
-
-  GST_CALL_PARENT (G_OBJECT_CLASS, constructed, (object));
 }

--- a/gst/gst-gtuber/gstgtuberdashdemux.c
+++ b/gst/gst-gtuber/gstgtuberdashdemux.c
@@ -57,25 +57,12 @@ gst_gtuber_dash_demux_init (GstGtuberDashDemux *self)
 }
 
 static void
-gst_gtuber_dash_demux_constructed (GObject* object)
-{
-  GstGtuberAdaptiveBin *adaptive_bin = GST_GTUBER_ADAPTIVE_BIN_CAST (object);
-
-  adaptive_bin->demuxer = gst_element_factory_make ("dashdemux", NULL);
-
-  GST_CALL_PARENT (G_OBJECT_CLASS, constructed, (object));
-}
-
-static void
 gst_gtuber_dash_demux_class_init (GstGtuberDashDemuxClass *klass)
 {
-  GObjectClass *gobject_class = (GObjectClass *) klass;
   GstElementClass *gstelement_class = (GstElementClass *) klass;
 
   GST_DEBUG_CATEGORY_INIT (gst_gtuber_dash_demux_debug, "gtuberdashdemux", 0,
       "Gtuber DASH demux");
-
-  gobject_class->constructed = gst_gtuber_dash_demux_constructed;
 
   gst_element_class_add_static_pad_template (gstelement_class, &sink_template);
   gst_element_class_add_static_pad_template (gstelement_class, &videosrc_template);

--- a/gst/gst-gtuber/gstgtuberhlsdemux.c
+++ b/gst/gst-gtuber/gstgtuberhlsdemux.c
@@ -43,8 +43,20 @@ G_DEFINE_TYPE_WITH_CODE (GstGtuberHlsDemux, gst_gtuber_hls_demux,
 GST_ELEMENT_REGISTER_DEFINE_WITH_CODE (gtuberhlsdemux, "gtuberhlsdemux",
     GST_RANK_PRIMARY + 10, GST_TYPE_GTUBER_HLS_DEMUX, gst_gtuber_element_init (plugin));
 
-/* GObject */
-static void gst_gtuber_hls_demux_constructed (GObject* object);
+static void
+gst_gtuber_hls_demux_init (GstGtuberHlsDemux *self)
+{
+}
+
+static void
+gst_gtuber_hls_demux_constructed (GObject* object)
+{
+  GstGtuberAdaptiveBin *adaptive_bin = GST_GTUBER_ADAPTIVE_BIN_CAST (object);
+
+  adaptive_bin->demuxer = gst_element_factory_make ("hlsdemux", NULL);
+
+  GST_CALL_PARENT (G_OBJECT_CLASS, constructed, (object));
+}
 
 static void
 gst_gtuber_hls_demux_class_init (GstGtuberHlsDemuxClass *klass)
@@ -64,19 +76,4 @@ gst_gtuber_hls_demux_class_init (GstGtuberHlsDemuxClass *klass)
       "Codec/Demuxer/Adaptive",
       "Demuxer for Gtuber HLS data",
       "Rafał Dzięgiel <rafostar.github@gmail.com>");
-}
-
-static void
-gst_gtuber_hls_demux_init (GstGtuberHlsDemux *self)
-{
-}
-
-static void
-gst_gtuber_hls_demux_constructed (GObject* object)
-{
-  GstGtuberAdaptiveBin *adaptive_bin = GST_GTUBER_ADAPTIVE_BIN_CAST (object);
-
-  adaptive_bin->demuxer = gst_element_factory_make ("hlsdemux", NULL);
-
-  GST_CALL_PARENT (G_OBJECT_CLASS, constructed, (object));
 }

--- a/gst/gst-gtuber/gstgtuberhlsdemux.c
+++ b/gst/gst-gtuber/gstgtuberhlsdemux.c
@@ -49,25 +49,12 @@ gst_gtuber_hls_demux_init (GstGtuberHlsDemux *self)
 }
 
 static void
-gst_gtuber_hls_demux_constructed (GObject* object)
-{
-  GstGtuberAdaptiveBin *adaptive_bin = GST_GTUBER_ADAPTIVE_BIN_CAST (object);
-
-  adaptive_bin->demuxer = gst_element_factory_make ("hlsdemux", NULL);
-
-  GST_CALL_PARENT (G_OBJECT_CLASS, constructed, (object));
-}
-
-static void
 gst_gtuber_hls_demux_class_init (GstGtuberHlsDemuxClass *klass)
 {
-  GObjectClass *gobject_class = (GObjectClass *) klass;
   GstElementClass *gstelement_class = (GstElementClass *) klass;
 
   GST_DEBUG_CATEGORY_INIT (gst_gtuber_hls_demux_debug, "gtuberhlsdemux", 0,
       "Gtuber HLS demux");
-
-  gobject_class->constructed = gst_gtuber_hls_demux_constructed;
 
   gst_element_class_add_static_pad_template (gstelement_class, &sink_template);
   gst_element_class_add_static_pad_template (gstelement_class, &src_template);

--- a/gst/gst-gtuber/gstgtubersrc.c
+++ b/gst/gst-gtuber/gstgtubersrc.c
@@ -299,9 +299,10 @@ gst_gtuber_src_push_events (GstGtuberSrc *self, GtuberMediaInfo *info)
   GST_DEBUG_OBJECT (self, "Creating TAG event");
   tags = gst_tag_list_new_empty ();
 
-  if ((tag = gtuber_media_info_get_title (info)))
+  /* GStreamer does not allow empty strings in the tag list */
+  if ((tag = gtuber_media_info_get_title (info)) && strlen (tag) > 0)
     gst_tag_list_add (tags, GST_TAG_MERGE_APPEND, GST_TAG_TITLE, tag, NULL);
-  if ((tag = gtuber_media_info_get_description (info)))
+  if ((tag = gtuber_media_info_get_description (info)) && strlen (tag) > 0)
     gst_tag_list_add (tags, GST_TAG_MERGE_APPEND, GST_TAG_DESCRIPTION, tag, NULL);
 
   if (gst_tag_list_is_empty (tags)) {

--- a/gst/gst-gtuber/gstgtuberuridemux.c
+++ b/gst/gst-gtuber/gstgtuberuridemux.c
@@ -43,68 +43,6 @@ G_DEFINE_TYPE_WITH_CODE (GstGtuberUriDemux, gst_gtuber_uri_demux,
 GST_ELEMENT_REGISTER_DEFINE_WITH_CODE (gtuberuridemux, "gtuberuridemux",
     GST_RANK_PRIMARY + 10, GST_TYPE_GTUBER_URI_DEMUX, gst_gtuber_element_init (plugin));
 
-/* GObject */
-static void gst_gtuber_uri_demux_finalize (GObject *object);
-
-/* GstPad */
-static gboolean gst_gtuber_uri_demux_sink_event (GstPad *pad,
-    GstObject *parent, GstEvent *event);
-static GstFlowReturn gst_gtuber_uri_demux_sink_chain (GstPad *pad,
-    GstObject *parent, GstBuffer *buffer);
-
-static void
-gst_gtuber_uri_demux_class_init (GstGtuberUriDemuxClass *klass)
-{
-  GObjectClass *gobject_class = (GObjectClass *) klass;
-  GstElementClass *gstelement_class = (GstElementClass *) klass;
-
-  GST_DEBUG_CATEGORY_INIT (gst_gtuber_uri_demux_debug, "gtuberuridemux", 0,
-      "Gtuber URI demux");
-
-  gobject_class->finalize = gst_gtuber_uri_demux_finalize;
-
-  gst_element_class_add_static_pad_template (gstelement_class, &sink_template);
-  gst_element_class_add_static_pad_template (gstelement_class, &src_template);
-
-  gst_element_class_set_static_metadata (gstelement_class, "Gtuber URI demuxer",
-      "Codec/Demuxer",
-      "Demuxer for Gtuber stream URI",
-      "Rafał Dzięgiel <rafostar.github@gmail.com>");
-}
-
-static void
-gst_gtuber_uri_demux_init (GstGtuberUriDemux *self)
-{
-  GstPad *sink_pad;
-
-  self->input_adapter = gst_adapter_new ();
-
-  sink_pad = gst_pad_new_from_template (gst_element_class_get_pad_template (
-      GST_ELEMENT_GET_CLASS (self), "sink"), "sink");
-  gst_pad_set_event_function (sink_pad,
-      GST_DEBUG_FUNCPTR (gst_gtuber_uri_demux_sink_event));
-  gst_pad_set_chain_function (sink_pad,
-      GST_DEBUG_FUNCPTR (gst_gtuber_uri_demux_sink_chain));
-
-  gst_pad_set_active (sink_pad, TRUE);
-
-  if (!gst_element_add_pad (GST_ELEMENT (self), sink_pad))
-    g_critical ("Failed to add sink pad to bin");
-}
-
-static void
-gst_gtuber_uri_demux_finalize (GObject *object)
-{
-  GstGtuberUriDemux *self = GST_GTUBER_URI_DEMUX (object);
-
-  g_object_unref (self->input_adapter);
-
-  if (self->typefind_src)
-    g_object_unref (self->typefind_src);
-
-  GST_CALL_PARENT (G_OBJECT_CLASS, finalize, (object));
-}
-
 static gboolean
 gst_gtuber_uri_demux_process_buffer (GstGtuberUriDemux *self, GstBuffer *buffer)
 {
@@ -245,4 +183,57 @@ gst_gtuber_uri_demux_sink_chain (GstPad *pad, GstObject *parent, GstBuffer *buff
       (gint) gst_adapter_available (self->input_adapter));
 
   return GST_FLOW_OK;
+}
+
+static void
+gst_gtuber_uri_demux_init (GstGtuberUriDemux *self)
+{
+  GstPad *sink_pad;
+
+  self->input_adapter = gst_adapter_new ();
+
+  sink_pad = gst_pad_new_from_template (gst_element_class_get_pad_template (
+      GST_ELEMENT_GET_CLASS (self), "sink"), "sink");
+  gst_pad_set_event_function (sink_pad,
+      GST_DEBUG_FUNCPTR (gst_gtuber_uri_demux_sink_event));
+  gst_pad_set_chain_function (sink_pad,
+      GST_DEBUG_FUNCPTR (gst_gtuber_uri_demux_sink_chain));
+
+  gst_pad_set_active (sink_pad, TRUE);
+
+  if (!gst_element_add_pad (GST_ELEMENT (self), sink_pad))
+    g_critical ("Failed to add sink pad to bin");
+}
+
+static void
+gst_gtuber_uri_demux_finalize (GObject *object)
+{
+  GstGtuberUriDemux *self = GST_GTUBER_URI_DEMUX (object);
+
+  g_object_unref (self->input_adapter);
+
+  if (self->typefind_src)
+    g_object_unref (self->typefind_src);
+
+  GST_CALL_PARENT (G_OBJECT_CLASS, finalize, (object));
+}
+
+static void
+gst_gtuber_uri_demux_class_init (GstGtuberUriDemuxClass *klass)
+{
+  GObjectClass *gobject_class = (GObjectClass *) klass;
+  GstElementClass *gstelement_class = (GstElementClass *) klass;
+
+  GST_DEBUG_CATEGORY_INIT (gst_gtuber_uri_demux_debug, "gtuberuridemux", 0,
+      "Gtuber URI demux");
+
+  gobject_class->finalize = gst_gtuber_uri_demux_finalize;
+
+  gst_element_class_add_static_pad_template (gstelement_class, &sink_template);
+  gst_element_class_add_static_pad_template (gstelement_class, &src_template);
+
+  gst_element_class_set_static_metadata (gstelement_class, "Gtuber URI demuxer",
+      "Codec/Demuxer",
+      "Demuxer for Gtuber stream URI",
+      "Rafał Dzięgiel <rafostar.github@gmail.com>");
 }


### PR DESCRIPTION
GStreamer 1.22 introduces new hls/dash demuxers subclassing new adaptivedemux2. These work only with streams aware elements like playbin3. Add support for them to our existing gtuber demuxers, so they will be used by default when possible.