### PR TITLE
bilibili: fix cid & aid type

### DIFF
--- a/plugins/bilibili/gtuber-bilibili-bangumi.c
+++ b/plugins/bilibili/gtuber-bilibili-bangumi.c
@@ -117,7 +117,7 @@ gchar *
 bilibili_bangumi_obtain_media_uri (GtuberBilibili *self, const gchar *id_name)
 {
   return g_strdup_printf (
-      "https://api.bilibili.com/pgc/player/web/playurl?avid=%i&cid=%i&bvid=%s&qn=0&fnver=0&fnval=80&fourk=1&%s=%s",
+      "https://api.bilibili.com/pgc/player/web/playurl?avid=%" G_GINT64_FORMAT "&cid=%" G_GINT64_FORMAT "&bvid=%s&qn=0&fnver=0&fnval=80&fourk=1&%s=%s",
       self->aid, self->cid, self->bvid, id_name, self->video_id);
 }
 

--- a/plugins/bilibili/gtuber-bilibili-normal.c
+++ b/plugins/bilibili/gtuber-bilibili-normal.c
@@ -32,7 +32,7 @@ gchar *
 bilibili_normal_obtain_media_uri (GtuberBilibili *self)
 {
   return g_strdup_printf (
-      "https://api.bilibili.com/x/player/playurl?aid=%i&cid=%i&bvid=%s&qn=0&fnver=0&fnval=80&fourk=1",
+      "https://api.bilibili.com/x/player/playurl?aid=%" G_GINT64_FORMAT "&cid=%" G_GINT64_FORMAT "&bvid=%s&qn=0&fnver=0&fnval=80&fourk=1",
       self->aid, self->cid, self->bvid);
 }
 
@@ -66,7 +66,8 @@ bilibili_normal_parse_info (GtuberBilibili *self, JsonReader *reader,
     gint i, count = gtuber_utils_json_count_elements (reader, NULL);
 
     for (i = 0; i < count; i++) {
-      guint el_cid, duration;
+      gint64 el_cid;
+      guint duration;
 
       el_cid = gtuber_utils_json_get_int (reader,
           GTUBER_UTILS_JSON_ARRAY_INDEX (i), "cid", NULL);

--- a/plugins/bilibili/gtuber-bilibili.c
+++ b/plugins/bilibili/gtuber-bilibili.c
@@ -51,7 +51,7 @@ void bilibili_set_media_info_id_from_cid (GtuberBilibili *self, GtuberMediaInfo 
 {
   gchar *id;
 
-  id = g_strdup_printf ("%i", self->cid);
+  id = g_strdup_printf ("%" G_GINT64_FORMAT, self->cid);
   gtuber_media_info_set_id (info, id);
   g_debug ("Video ID: %s", id);
 
@@ -325,7 +325,7 @@ gtuber_bilibili_parse_input_stream (GtuberWebsite *website,
 GtuberFlow
 bilibili_get_flow_from_plugin_props (GtuberBilibili *self, GError **error)
 {
-  g_debug ("Has bvid: %s, aid: %i, cid: %i",
+  g_debug ("Has bvid: %s, aid: %" G_GINT64_FORMAT ", cid: %" G_GINT64_FORMAT,
       self->bvid, self->aid, self->cid);
 
   /* We have info that we are going to use

--- a/plugins/bilibili/gtuber-bilibili.h
+++ b/plugins/bilibili/gtuber-bilibili.h
@@ -44,8 +44,8 @@ struct _GtuberBilibili
 
   /* Parsed from response */
   gchar *bvid;
-  guint aid;
-  guint cid;
+  gint64 aid;
+  gint64 cid;
 
   BilibiliType bili_type;
 


### PR DESCRIPTION
aid & cid: from `guint` to `gint64`

this ensure new videos' information successfully extracted, rather than integer overflow.